### PR TITLE
Fix incorrect order of operations in ws2812

### DIFF
--- a/src/device/ws2812.rs
+++ b/src/device/ws2812.rs
@@ -35,7 +35,7 @@ impl Device for Ws2812 {
                 let mut obits: u32 = 0;
                 for i in 0..8 {
                     let middle_bit = (b >> i) & 1;
-                    obits |= 0b100 << (i * 3) | u32::from(middle_bit << 1);
+                    obits |= (0b100 | u32::from(middle_bit << 1)) << (i * 3);
                 }
                 vec![
                     ((obits >> 16) & 0xff) as u8,


### PR DESCRIPTION
The original code was repeatedly setting the lowest group's middle bit, meaning that the LEDs would only turn on very dimly. This patch makes it so that the middle bit of each group of 3 bits is set instead.